### PR TITLE
Add separate color for underlines

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -13,10 +13,10 @@ The default theme.toml can be found [here](https://github.com/helix-editor/helix
 Each line in the theme file is specified as below:
 
 ```toml
-key = { fg = "#ffffff", bg = "#000000", modifiers = ["bold", "italic"] }
+key = { fg = "#ffffff", bg = "#000000", underline = "#ff0000", modifiers = ["bold", "italic", "undercurled"] }
 ```
 
-where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, and `modifiers` is a list of style modifiers. `bg` and `modifiers` can be omitted to defer to the defaults.
+where `key` represents what you want to style, `fg` specifies the foreground color, `bg` the background color, `underline` the underline color (only meaningful if an underline modifier is enabled), and `modifiers` is a list of style modifiers. `bg`, `underline` and `modifiers` can be omitted to defer to the defaults.
 
 To specify only the foreground color:
 
@@ -77,17 +77,21 @@ The following values may be used as modifiers.
 
 Less common modifiers might not be supported by your terminal emulator.
 
-| Modifier       |
-| ---            |
-| `bold`         |
-| `dim`          |
-| `italic`       |
-| `underlined`   |
-| `slow_blink`   |
-| `rapid_blink`  |
-| `reversed`     |
-| `hidden`       |
-| `crossed_out`  |
+| Modifier             |
+| ---                  |
+| `bold`               |
+| `dim`                |
+| `italic`             |
+| `underlined`         |
+| `undercurled`        |
+| `underdashed`        |
+| `underdotted`        |
+| `double-underlined`  |
+| `slow_blink`         |
+| `rapid_blink`        |
+| `reversed`           |
+| `hidden`             |
+| `crossed_out`        |
 
 ### Scopes
 

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -4,7 +4,7 @@ use crossterm::{
     execute, queue,
     style::{
         Attribute as CAttribute, Color as CColor, Print, SetAttribute, SetBackgroundColor,
-        SetForegroundColor,
+        SetForegroundColor, SetUnderlineColor,
     },
     terminal::{self, Clear, ClearType},
 };
@@ -47,6 +47,7 @@ where
     {
         let mut fg = Color::Reset;
         let mut bg = Color::Reset;
+        let mut underline = Color::Reset;
         let mut modifier = Modifier::empty();
         let mut last_pos: Option<(u16, u16)> = None;
         for (x, y, cell) in content {
@@ -72,6 +73,11 @@ where
                 let color = CColor::from(cell.bg);
                 map_error(queue!(self.buffer, SetBackgroundColor(color)))?;
                 bg = cell.bg;
+            }
+            if cell.underline != underline {
+                let color = CColor::from(cell.underline);
+                map_error(queue!(self.buffer, SetUnderlineColor(color)))?;
+                underline = cell.underline;
             }
 
             map_error(queue!(self.buffer, Print(&cell.symbol)))?;

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -57,7 +57,7 @@ impl Cell {
         Style::default()
             .fg(self.fg)
             .bg(self.bg)
-            .underline(self.bg)
+            .underline(self.underline)
             .add_modifier(self.modifier)
     }
 
@@ -104,7 +104,8 @@ impl Default for Cell {
 ///     symbol: String::from("r"),
 ///     fg: Color::Red,
 ///     bg: Color::White,
-///     modifier: Modifier::empty()
+///     underline: Color::Reset,
+///     modifier: Modifier::empty(),
 /// });
 /// buf[(5, 0)].set_char('x');
 /// assert_eq!(buf[(5, 0)].symbol, "x");

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -11,6 +11,7 @@ pub struct Cell {
     pub symbol: String,
     pub fg: Color,
     pub bg: Color,
+    pub underline: Color,
     pub modifier: Modifier,
 }
 
@@ -44,6 +45,9 @@ impl Cell {
         if let Some(c) = style.bg {
             self.bg = c;
         }
+        if let Some(c) = style.underline {
+            self.underline = c;
+        }
         self.modifier.insert(style.add_modifier);
         self.modifier.remove(style.sub_modifier);
         self
@@ -53,6 +57,7 @@ impl Cell {
         Style::default()
             .fg(self.fg)
             .bg(self.bg)
+            .underline(self.bg)
             .add_modifier(self.modifier)
     }
 
@@ -61,6 +66,7 @@ impl Cell {
         self.symbol.push(' ');
         self.fg = Color::Reset;
         self.bg = Color::Reset;
+        self.underline = Color::Reset;
         self.modifier = Modifier::empty();
     }
 }
@@ -71,6 +77,7 @@ impl Default for Cell {
             symbol: " ".into(),
             fg: Color::Reset,
             bg: Color::Reset,
+            underline: Color::Reset,
             modifier: Modifier::empty(),
         }
     }

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -134,6 +134,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -143,6 +144,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -152,6 +154,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },
@@ -161,6 +164,7 @@ impl<'a> Span<'a> {
     ///             style: Style {
     ///                 fg: Some(Color::Yellow),
     ///                 bg: Some(Color::Black),
+    ///                 underline: None,
     ///                 add_modifier: Modifier::empty(),
     ///                 sub_modifier: Modifier::empty(),
     ///             },

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -440,6 +440,7 @@ impl FromStr for Modifier {
 pub struct Style {
     pub fg: Option<Color>,
     pub bg: Option<Color>,
+    pub underline: Option<Color>,
     pub add_modifier: Modifier,
     pub sub_modifier: Modifier,
 }
@@ -449,6 +450,7 @@ impl Default for Style {
         Style {
             fg: None,
             bg: None,
+            underline: None,
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::empty(),
         }
@@ -461,6 +463,7 @@ impl Style {
         Style {
             fg: Some(Color::Reset),
             bg: Some(Color::Reset),
+            underline: Some(Color::Reset),
             add_modifier: Modifier::empty(),
             sub_modifier: Modifier::all(),
         }
@@ -493,6 +496,21 @@ impl Style {
     /// ```
     pub fn bg(mut self, color: Color) -> Style {
         self.bg = Some(color);
+        self
+    }
+
+    /// Changes the underline color.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use helix_view::graphics::{Color, Style};
+    /// let style = Style::default().underline(Color::Blue);
+    /// let diff = Style::default().underline(Color::Red);
+    /// assert_eq!(style.patch(diff), Style::default().underline(Color::Red));
+    /// ```
+    pub fn underline(mut self, color: Color) -> Style {
+        self.underline = Some(color);
         self
     }
 
@@ -552,6 +570,7 @@ impl Style {
     pub fn patch(mut self, other: Style) -> Style {
         self.fg = other.fg.or(self.fg);
         self.bg = other.bg.or(self.bg);
+        self.underline = other.underline.or(self.bg);
 
         self.add_modifier.remove(other.sub_modifier);
         self.add_modifier.insert(other.add_modifier);

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -404,6 +404,7 @@ impl FromStr for Modifier {
 ///     Style {
 ///         fg: Some(Color::Yellow),
 ///         bg: Some(Color::Red),
+///         underline: Some(Color::Reset),
 ///         add_modifier: Modifier::BOLD,
 ///         sub_modifier: Modifier::empty(),
 ///     },
@@ -429,6 +430,7 @@ impl FromStr for Modifier {
 ///     Style {
 ///         fg: Some(Color::Yellow),
 ///         bg: Some(Color::Reset),
+///         underline: Some(Color::Reset),
 ///         add_modifier: Modifier::empty(),
 ///         sub_modifier: Modifier::empty(),
 ///     },
@@ -570,7 +572,7 @@ impl Style {
     pub fn patch(mut self, other: Style) -> Style {
         self.fg = other.fg.or(self.fg);
         self.bg = other.bg.or(self.bg);
-        self.underline = other.underline.or(self.bg);
+        self.underline = other.underline.or(self.underline);
 
         self.add_modifier.remove(other.sub_modifier);
         self.add_modifier.insert(other.add_modifier);

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -269,6 +269,7 @@ impl ThemePalette {
                 match name.as_str() {
                     "fg" => *style = style.fg(self.parse_color(value)?),
                     "bg" => *style = style.bg(self.parse_color(value)?),
+                    "underline" => *style = style.underline(self.parse_color(value)?),
                     "modifiers" => {
                         let modifiers = value
                             .as_array()

--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -86,7 +86,8 @@
 "info" = { fg = "light_blue" }
 "hint" = { fg = "light_gray3" }
 
-diagnostic = { modifiers = ["underlined"] }
+"diagnostic.error" = {underline = "red", modifiers = ["undercurled"] }
+"diagnostic" = {underline = "gold", modifiers = ["undercurled"] }
 
 [palette]
 white = "#ffffff"


### PR DESCRIPTION
Continuing your work on undercurl, I added separate colors for underlines :)
![image](https://user-images.githubusercontent.com/58790821/184121360-48f064f6-bee2-473f-8c6b-e41af7178170.png)
![image](https://user-images.githubusercontent.com/58790821/184121406-de86d579-28b1-40fc-a2f5-872ceb2b8058.png)

Still need to make it check whether these features are supported.