### PR TITLE
Request workspace symbols on idle-timeout

### DIFF
--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -163,15 +163,9 @@ impl<T: Item> FilePicker<T> {
     }
 
     fn handle_idle_timeout(&mut self, cx: &mut Context) -> EventResult {
-        self.highlight_current_file(cx.editor);
-
-        EventResult::Consumed(None)
-    }
-
-    pub fn highlight_current_file(&mut self, editor: &Editor) {
         // Try to find a document in the cache
         let doc = self
-            .current_file(editor)
+            .current_file(cx.editor)
             .and_then(|(path, _range)| self.preview_cache.get_mut(&path))
             .and_then(|cache| match cache {
                 CachedPreview::Document(doc) => Some(doc),
@@ -181,10 +175,12 @@ impl<T: Item> FilePicker<T> {
         // Then attempt to highlight it if it has no language set
         if let Some(doc) = doc {
             if doc.language_config().is_none() {
-                let loader = editor.syn_loader.clone();
+                let loader = cx.editor.syn_loader.clone();
                 doc.detect_language(loader);
             }
         }
+
+        EventResult::Consumed(None)
     }
 }
 
@@ -734,20 +730,16 @@ impl<T: Item + Send + 'static> Component for DynamicPicker<T> {
 
         cx.jobs.callback(async move {
             let new_options = new_options.await?;
-            let callback: crate::job::Callback = Box::new(move |editor, compositor| {
+            let callback: crate::job::Callback = Box::new(move |_editor, compositor| {
                 // Wrapping of pickers in overlay is done outside the picker code,
                 // so this is fragile and will break if wrapped in some other widget.
-                let file_picker = match compositor.find_id::<Overlay<DynamicPicker<T>>>(Self::ID) {
-                    Some(overlay) => &mut overlay.content.file_picker,
+                let picker = match compositor.find_id::<Overlay<DynamicPicker<T>>>(Self::ID) {
+                    Some(overlay) => &mut overlay.content.file_picker.picker,
                     None => return,
                 };
-                file_picker.picker.options = new_options;
-                file_picker.picker.cursor = 0;
-                file_picker.picker.force_score();
-                // This callback is triggered on the idle timeout, so we simulate the
-                // file-picker's handle_idle_timeout behavior by highlighting the
-                // currently previewed file.
-                file_picker.highlight_current_file(editor);
+                picker.options = new_options;
+                picker.cursor = 0;
+                picker.force_score();
             });
             anyhow::Ok(callback)
         });


### PR DESCRIPTION
Hey sudormrfbin 😀

This is a change on top of #3110 that uses the idle-timeout as a debounce.

The call to highlight the current file feels slightly hacky to me. What do you think?